### PR TITLE
Support R 3.2.0 and above

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ Imports:
   httr,
   jsonlite
 Depends:
-    R (>= 3.2.3)
+    R (>= 3.2.0)
 License: MIT License + file LICENSE
 LazyData: true
 RoxygenNote: 5.0.1.9000


### PR DESCRIPTION
Removing unnecessary version minimum; tested locally
